### PR TITLE
Elixir 1.5 child specs - removed deprecated Supervisor.Spec module

### DIFF
--- a/apps/aecore/lib/aecore.ex
+++ b/apps/aecore/lib/aecore.ex
@@ -2,14 +2,12 @@ defmodule Aecore do
   use Application
 
   def start(_type, _args) do
-    import Supervisor.Spec
-
     children = [
-      supervisor(Aecore.Keys.Worker.Supervisor, []),
-      supervisor(Aecore.Chain.Worker.Supervisor, []),
-      supervisor(Aecore.Miner.Worker.Supervisor, []),
-      supervisor(Aecore.Txs.Pool.Worker.Supervisor, []),
-      supervisor(Aecore.Peers.Worker.Supervisor, [])
+      Aecore.Keys.Worker.Supervisor,
+      Aecore.Chain.Worker.Supervisor,
+      Aecore.Miner.Worker.Supervisor,
+      Aecore.Txs.Pool.Worker.Supervisor,
+      Aecore.Peers.Worker.Supervisor
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/apps/aecore/lib/aecore/chain/worker.ex
+++ b/apps/aecore/lib/aecore/chain/worker.ex
@@ -13,7 +13,7 @@ defmodule Aecore.Chain.Worker do
 
   use GenServer
 
-  def start_link do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, {}, name: __MODULE__)
   end
 

--- a/apps/aecore/lib/aecore/chain/worker/supervisor.ex
+++ b/apps/aecore/lib/aecore/chain/worker/supervisor.ex
@@ -1,15 +1,15 @@
 defmodule Aecore.Chain.Worker.Supervisor do
   use Supervisor
 
-  def start_link() do
+  def start_link(_args) do
     Supervisor.start_link(__MODULE__, :ok)
   end
 
   def init(:ok) do
     children = [
-      worker(Aecore.Chain.Worker, [])
+     Aecore.Chain.Worker
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/apps/aecore/lib/aecore/keys/worker.ex
+++ b/apps/aecore/lib/aecore/keys/worker.ex
@@ -11,7 +11,7 @@ defmodule Aecore.Keys.Worker do
   @filename_priv "key"
   @pub_key_length 65
 
-  def start_link() do
+  def start_link(_args) do
     GenServer.start_link(
       __MODULE__,
       %{

--- a/apps/aecore/lib/aecore/keys/worker/supervisor.ex
+++ b/apps/aecore/lib/aecore/keys/worker/supervisor.ex
@@ -1,15 +1,15 @@
 defmodule Aecore.Keys.Worker.Supervisor do
   use Supervisor
 
-  def start_link() do
+  def start_link(_args) do
     Supervisor.start_link(__MODULE__, :ok)
   end
 
   def init(:ok) do
     children = [
-      worker(Aecore.Keys.Worker, [])
+      Aecore.Keys.Worker
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/apps/aecore/lib/aecore/miner/worker.ex
+++ b/apps/aecore/lib/aecore/miner/worker.ex
@@ -18,8 +18,18 @@ defmodule Aecore.Miner.Worker do
   @coinbase_transaction_value 100
   @nonce_per_cycle 1
 
-  def start_link() do
+  def start_link(_args) do
     GenStateMachine.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]},
+      restart: :permanent,
+      shutdown: 5000,
+      type: :worker
+    }
   end
 
   def resume() do

--- a/apps/aecore/lib/aecore/miner/worker/supervisor.ex
+++ b/apps/aecore/lib/aecore/miner/worker/supervisor.ex
@@ -1,15 +1,15 @@
 defmodule Aecore.Miner.Worker.Supervisor do
   use Supervisor
 
-  def start_link() do
+  def start_link(_args) do
     Supervisor.start_link(__MODULE__, :ok)
   end
 
   def init(:ok) do
     children = [
-      worker(Aecore.Miner.Worker, [])
+      Aecore.Miner.Worker
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/apps/aecore/lib/aecore/peers/scheduler.ex
+++ b/apps/aecore/lib/aecore/peers/scheduler.ex
@@ -5,7 +5,7 @@ defmodule Aecore.Peers.Scheduler do
 
   @check_time 60_000
 
-  def start_link do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, %{})
   end
 

--- a/apps/aecore/lib/aecore/peers/worker.ex
+++ b/apps/aecore/lib/aecore/peers/worker.ex
@@ -14,7 +14,7 @@ defmodule Aecore.Peers.Worker do
 
   require Logger
 
-  def start_link do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 

--- a/apps/aecore/lib/aecore/peers/worker/supervisor.ex
+++ b/apps/aecore/lib/aecore/peers/worker/supervisor.ex
@@ -1,16 +1,16 @@
 defmodule Aecore.Peers.Worker.Supervisor do
   use Supervisor
 
-  def start_link() do
+  def start_link(_args) do
     Supervisor.start_link(__MODULE__, :ok)
   end
 
   def init(:ok) do
     children = [
-      worker(Aecore.Peers.Worker, []),
-      worker(Aecore.Peers.Scheduler, [])
+      Aecore.Peers.Worker,
+      Aecore.Peers.Scheduler
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/apps/aecore/lib/aecore/txs/pool/worker.ex
+++ b/apps/aecore/lib/aecore/txs/pool/worker.ex
@@ -12,7 +12,7 @@ defmodule Aecore.Txs.Pool.Worker do
 
   require Logger
 
-  def start_link do
+  def start_link(_args) do
     GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 

--- a/apps/aecore/lib/aecore/txs/pool/worker/supervisor.ex
+++ b/apps/aecore/lib/aecore/txs/pool/worker/supervisor.ex
@@ -1,15 +1,15 @@
 defmodule Aecore.Txs.Pool.Worker.Supervisor do
   use Supervisor
 
-  def start_link() do
+  def start_link(_args) do
     Supervisor.start_link(__MODULE__, :ok)
   end
 
   def init(:ok) do
     children = [
-      worker(Aecore.Txs.Pool.Worker, [])
+      Aecore.Txs.Pool.Worker
     ]
 
-    supervise(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/apps/aecore/test/aecore_chain_test.exs
+++ b/apps/aecore/test/aecore_chain_test.exs
@@ -13,7 +13,7 @@ defmodule AecoreChainTest do
   alias Aecore.Miner.Worker, as: Miner
 
   setup do
-    Chain.start_link()
+    Chain.start_link([])
     []
   end
 

--- a/apps/aecore/test/aecore_keys_test.exs
+++ b/apps/aecore/test/aecore_keys_test.exs
@@ -10,7 +10,7 @@ defmodule AecoreKeysTest do
   alias Aecore.Chain.Worker, as: Chain
 
   setup do
-    Keys.start_link()
+    Keys.start_link([])
     []
   end
 

--- a/apps/aecore/test/aecore_miner_test.exs
+++ b/apps/aecore/test/aecore_miner_test.exs
@@ -7,7 +7,7 @@ defmodule MinerTest do
 
   @tag timeout: 100000000
   test "mine_next_block" do
-    Miner.start_link()
+    Miner.start_link([])
     Miner.resume()
     Miner.suspend()
     assert length(Chain.all_blocks) > 1

--- a/apps/aecore/test/aecore_peers_test.exs
+++ b/apps/aecore/test/aecore_peers_test.exs
@@ -5,7 +5,7 @@ defmodule AecorePeersTest do
   alias Aecore.Peers.Worker, as: Peers
 
   setup do
-    Peers.start_link()
+    Peers.start_link([])
     []
   end
 

--- a/apps/aecore/test/aecore_tx_test.exs
+++ b/apps/aecore/test/aecore_tx_test.exs
@@ -9,7 +9,7 @@ defmodule AecoreTxTest do
   alias Aecore.Chain.Worker, as: Chain
 
   setup do
-    Keys.start_link()
+    Keys.start_link([])
     []
   end
 

--- a/apps/aecore/test/aecore_txs_pool_test.exs
+++ b/apps/aecore/test/aecore_txs_pool_test.exs
@@ -10,7 +10,7 @@ defmodule AecoreTxsPoolTest do
   alias Aecore.Keys.Worker, as: Keys
 
   setup do
-    Pool.start_link()
+    Pool.start_link([])
     []
   end
 

--- a/apps/aecore/test/multiple_transactions_test.exs
+++ b/apps/aecore/test/multiple_transactions_test.exs
@@ -13,7 +13,7 @@ defmodule MultipleTransactionsTest do
   alias Aecore.Chain.Worker, as: Chain
 
   setup do
-    Pool.start_link()
+    Pool.start_link([])
     []
   end
 


### PR DESCRIPTION
Sorry if I'm intruding.

I noticed that your supervisors were written in the pre-1.5 style, so I thought I'd go ahead and fix it. Supervisor.Spec was [deprecated](https://hexdocs.pm/elixir/Supervisor.Spec.html) in the 1.5 release, now modules must implement a child_spec/1 function that describes how they are to be started, restarted, etc... The __using__ macro for GenServer automatically defines this, so no worries there.

Anyway, cool project, I'm glad you guys are showing interest in Elixir. It's an amazing language.