### PR TITLE
[GH-129] Fix peer sync (and small optimization)

### DIFF
--- a/apps/aecore/config/dev.exs
+++ b/apps/aecore/config/dev.exs
@@ -61,5 +61,5 @@ config :aecore, :pow,
   }
 
 config :aecore, :peers,
-  peers_target_count: 2,
+  peers_target_count: 3,
   peers_max_count: 4

--- a/apps/aecore/lib/aecore/peers/sync.ex
+++ b/apps/aecore/lib/aecore/peers/sync.ex
@@ -5,6 +5,9 @@ defmodule Aecore.Peers.Sync do
 
   alias Aecore.Peers.Worker, as: Peers
   alias Aehttpclient.Client, as: HttpClient
+  alias Aecore.Chain.Worker, as: Chain
+  alias Aecore.Utils.Blockchain.BlockValidation
+  alias Aecore.Utils.Serialization
 
   use GenServer
 
@@ -98,7 +101,8 @@ defmodule Aecore.Peers.Sync do
     |> Enum.shuffle
     |> Enum.take(Enum.min([@peers_target_count - known_count, known_count]))
     |> Enum.reduce(0, fn(peer, acc) ->
-      case Peers.add_peer(peer) do
+      peer_uri = elem(peer, 0)
+      case Peers.add_peer(peer_uri) do
         :ok -> acc+1
         _ -> acc
       end

--- a/apps/aecore/lib/aecore/peers/worker.ex
+++ b/apps/aecore/lib/aecore/peers/worker.ex
@@ -92,7 +92,7 @@ defmodule Aecore.Peers.Worker do
     if Map.has_key?(peers, uri) do
       Logger.debug(fn ->
         "Skipped adding #{uri}, already known" end)
-      {:reply, {:error, "Peer already known"}, peers}
+      {:reply, {:error, "Peer already known"}, state}
     else
       case check_peer(uri, own_nonce) do
         {:ok, info} ->

--- a/apps/aecore/lib/aecore/peers/worker.ex
+++ b/apps/aecore/lib/aecore/peers/worker.ex
@@ -10,6 +10,7 @@ defmodule Aecore.Peers.Worker do
   alias Aecore.Utils.Blockchain.BlockValidation
   alias Aehttpclient.Client, as: HttpClient
   alias Aecore.Utils.Serialization
+  alias Aecore.Peers.Sync
 
   require Logger
 


### PR DESCRIPTION
This PR:
- introduces a fix to peer sync (wrong parameters to `add_peer` call) (cherry-picked commit cd1dbfbd52ef0250d9)
- optimises peer sync - now we try to add another peer when one fails to be added. This is especially important in network with very small number of peers (like in development).
- fixes peers state when adding already known peer. (state was getting broken in such case)

This closes #129 