### PR TITLE
[GH-140] Re-added: equal nonce is not an error

### DIFF
--- a/apps/aecore/lib/aecore/peers/worker.ex
+++ b/apps/aecore/lib/aecore/peers/worker.ex
@@ -185,6 +185,8 @@ defmodule Aecore.Peers.Worker do
             Logger.debug(fn -> "Max peers reached. #{uri} not added" end)
             {:reply, :ok, state}
           end
+        {:error, "Equal peer nonces"} ->
+          {:reply, :ok, state}
         {:error, reason} ->
           Logger.error(fn -> "Failed to add peer. reason=#{reason}" end)
           {:reply, {:error, reason}, state}


### PR DESCRIPTION
This fixes problem added by #140. If nonce is equal we treat "add_peer" invocation as successful again.

The problem was introduced by c71576b6d8c2750fd266e3c68fa638f53aa3d0f4. Relevant comments are under #140.