### PR TITLE
erlang 20.2 and elixir 1.6.0 support

### DIFF
--- a/apps/aecore/mix.exs
+++ b/apps/aecore/mix.exs
@@ -46,7 +46,7 @@ defmodule Aecore.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:rox, "~> 2.1"},
+      {:rox, "~> 2.2.1"},
       {:exconstructor, "~> 1.1"},
       {:gb_merkle_trees, git: "https://github.com/aeternity/gb_merkle_trees.git", ref: "4db7aad"},
       {:excoveralls, "~> 0.7", only: :test},
@@ -64,7 +64,7 @@ defmodule Mix.Tasks.Compile.Make do
 
   def run(_) do
     File.cd(Path.absname("apps/aecore/src/cuckoo/"))
-    {result, _error_code} = System.cmd("make", ['all'], stderr_to_stdout: true)
+    {result, _error_code} = System.cmd("make", ["all"], stderr_to_stdout: true)
     Mix.shell.info result
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EpochElixir.Mixfile do
     [app: :epoch_elixir,
      apps_path: "apps",
      version: "0.1.0",
-     elixir: "~> 1.5.1",
+     elixir: "> 1.5.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EpochElixir.Mixfile do
     [app: :epoch_elixir,
      apps_path: "apps",
      version: "0.1.0",
-     elixir: "> 1.5.1",
+     elixir: ">= 1.5.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),


### PR DESCRIPTION
This makes compilation work on erlang 20.2 (with enif_select support and C NIF API update) and elixir 1.6.0, I am not sure if other issues can arise.