### PR TITLE
[GH-#216] Lazy read from rocksdb

### DIFF
--- a/apps/aecore/config/config.exs
+++ b/apps/aecore/config/config.exs
@@ -38,7 +38,8 @@ persistence_path = case System.get_env("PERSISTENCE_PATH") do
 end
 
 config :aecore, :persistence,
-  path: Path.absname(persistence_path)
+  path: Path.absname(persistence_path),
+  number_of_blocks_in_memory: 100
 
 config :logger,
   compile_time_purge_level: :info,

--- a/apps/aecore/lib/aecore/chain/worker.ex
+++ b/apps/aecore/lib/aecore/chain/worker.ex
@@ -167,7 +167,7 @@ defmodule Aecore.Chain.Worker do
 
     updated_blocks_map  = Map.put(blocks_map, new_block_hash, new_block)
     hundred_blocks_map  =
-    if Kernel.map_size(updated_blocks_map) > 100 do
+    if Kernel.map_size(updated_blocks_map) > number_of_blocks_in_memory() do
       [{_,b} | sorted_blocks] =
         Enum.sort(updated_blocks_map,
           fn({_,b1}, {_,b2}) ->
@@ -231,7 +231,7 @@ defmodule Aecore.Chain.Worker do
       end
 
     blocks_map =
-      case Persistence.get_blocks(100) do
+      case Persistence.get_blocks(number_of_blocks_in_memory()) do
         blocks_map when blocks_map == %{} -> state.blocks_map
         blocks_map -> blocks_map
       end
@@ -294,5 +294,9 @@ defmodule Aecore.Chain.Worker do
     else
       blocks_acc
     end
+  end
+
+  defp number_of_blocks_in_memory() do
+    Application.get_env(:aecore, :persistence)[:number_of_blocks_in_memory]
   end
 end

--- a/apps/aecore/lib/aecore/chain/worker.ex
+++ b/apps/aecore/lib/aecore/chain/worker.ex
@@ -168,13 +168,13 @@ defmodule Aecore.Chain.Worker do
     updated_blocks_map  = Map.put(blocks_map, new_block_hash, new_block)
     hundred_blocks_map  =
     if Kernel.map_size(updated_blocks_map) > number_of_blocks_in_memory() do
-      [{_,b} | sorted_blocks] =
+      [genesis_block, {_, b} | sorted_blocks] =
         Enum.sort(updated_blocks_map,
           fn({_,b1}, {_,b2}) ->
             b1.header.height < b2.header.height
           end)
       Logger.info("Block ##{b.header.height} has been removed from memory")
-      Enum.into(sorted_blocks, %{})
+      Enum.into([genesis_block | sorted_blocks], %{})
     else
       updated_blocks_map
     end

--- a/apps/aecore/lib/aecore/chain/worker.ex
+++ b/apps/aecore/lib/aecore/chain/worker.ex
@@ -171,7 +171,7 @@ defmodule Aecore.Chain.Worker do
       [{_,b} | sorted_blocks] =
         Enum.sort(updated_blocks_map,
           fn({_,b1}, {_,b2}) ->
-            b1.header.timestamp < b2.header.timestamp
+            b1.header.height < b2.header.height
           end)
       Logger.info("Block ##{b.header.height} has been removed from memory")
       Enum.into(sorted_blocks, %{})

--- a/apps/aecore/lib/aecore/chain/worker.ex
+++ b/apps/aecore/lib/aecore/chain/worker.ex
@@ -231,7 +231,7 @@ defmodule Aecore.Chain.Worker do
       end
 
     blocks_map =
-      case Persistence.get_hundred_blocks() do
+      case Persistence.get_blocks(100) do
         blocks_map when blocks_map == %{} -> state.blocks_map
         blocks_map -> blocks_map
       end

--- a/apps/aecore/lib/aecore/persistence/worker.ex
+++ b/apps/aecore/lib/aecore/persistence/worker.ex
@@ -41,10 +41,15 @@ defmodule Aecore.Persistence.Worker do
   end
   def get_block_by_hash(_hash), do: {:error, "bad hash value"}
 
-  @spec get_hundred_blocks() ::
+  @doc """
+  Retrieving last 'num' blocks from db. If have less than 'num' blocks,
+  then we will retrieve all blocks. The 'num' must be integer and greater
+  than one
+  """
+  @spec get_blocks(integer()) ::
   {:ok, map()} | :not_found | {:error, reason :: term()}
-  def get_hundred_blocks() do
-    GenServer.call(__MODULE__, :get_hundred_blocks)
+  def get_blocks(num) do
+    GenServer.call(__MODULE__, {:get_blocks, num})
   end
 
   @spec get_all_blocks() ::
@@ -144,26 +149,34 @@ defmodule Aecore.Persistence.Worker do
     {:reply, Rox.get(chain_state_family, account), state}
   end
 
-  def handle_call(:get_hundred_blocks, _from,
+  def handle_call({:get_blocks, blocks_num}, _from, state) when blocks_num < 1 do
+    {:reply, "Blocks number must be greater than one", state}
+  end
+
+  def handle_call({:get_blocks, blocks_num}, _from,
     %{blocks_family: blocks_family} = state) do
-    all_blocks =
+
+    max_blocks_height = Rox.count(blocks_family)
+    threshold = max_blocks_height - blocks_num
+
+    last_blocks =
+    if threshold < 0 do
       blocks_family
       |> Rox.stream()
       |> Enum.into([])
-
-    hundred_blocks =
-    if length(all_blocks) > 100 do
-      list = Enum.sort(all_blocks,
-        fn({_,b1}, {_,b2}) ->
-          b1.header.timestamp > b2.header.timestamp
-        end)
-      Enum.take(list, 5)
     else
-      all_blocks
+        Enum.reduce(Rox.stream(blocks_family), [],
+          fn({hash, %{header: %{height: height}} = block} = record, acc) ->
+            if threshold < height do
+              [record | acc]
+            else
+              acc
+            end
+          end)
     end
-    {:reply, Enum.into(hundred_blocks, %{}), state}
-  end
 
+    {:reply, Enum.into(last_blocks, %{}), state}
+  end
 
   def handle_call(:get_all_blocks, _from,
     %{blocks_family: blocks_family} = state) do

--- a/apps/aecore/test/aecore_persistence_test.exs
+++ b/apps/aecore/test/aecore_persistence_test.exs
@@ -54,6 +54,13 @@ defmodule PersistenceTest do
 
   end
 
+  @tag timeout: 10_000
+  @tag :persistence
+  test "Get latest two blocks from rocksdb" do
+    assert 2 == Kernel.map_size(Persistence.get_blocks(2))
+  end
+
+  @tag timeout: 20_000
   @tag :persistence
   test "Failure cases", persistance_state do
     assert {:error, "bad block structure"} =
@@ -63,5 +70,7 @@ defmodule PersistenceTest do
       Aecore.Persistence.Worker.get_block_by_hash(:wrong_input_type)
 
     assert :not_found = Persistence.get_account_chain_state(persistance_state.account2)
+
+    assert "Blocks number must be greater than one" == Persistence.get_blocks(0)
   end
 end


### PR DESCRIPTION
### What this PR does:

- Keep only 100 blocks in memory;
- On start-up load 100 blocks from rocksdb;
- On batch blocks requests first we check in memory if the block is not found then we check in rocksdb;

Closes #216 